### PR TITLE
HuggingFace `resume_download` is deprecated and will be removed in ve…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -79,7 +79,6 @@ class LoadOOTDPipelineHub(LoadOOTDPipeline):
         path = snapshot_download(
             self.repo_id,
             revision=self.repo_revision,
-            resume_download=True,
         )
         if os.path.exists("models/OOTDiffusion"):
             warnings.warn(


### PR DESCRIPTION
…rsion 1.0.0.

FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume w hen possible. If you want to force a new download, use `force_download=True`.