### PR TITLE
Update requirements.txt so it won't download incapable version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scipy
 scikit-image
 opencv-python
 pillow
-diffusers>=0.26.0
+diffusers==0.26.0
 transformers
 accelerate
 matplotlib


### PR DESCRIPTION
The command `diffusers>=0.26.0` will download higher diffusers versions now. I changed it to `diffusers==0.26.0`.